### PR TITLE
Add a test to run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,9 @@ sudo: required
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y tshark colordiff
-#  - sudo chown root /usr/bin/dumpcap
-#  - sudo chmod u+s /usr/bin/dumpcap
-#  - sudo setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' /usr/bin/dumpcap
-  # docs say to run as non-root one needs to change settings and log out/back in -
+  # docs say that to run as non-root one needs to change settings and log out/back in -
   # can't be done on travis so this is a workaround
-  # WARNING - don't do this to enable root to run scripts anywhere that isn't travis!
+  # DANGER - don't do any of the following lines apart from on travisci - it is to enable root to run scripts anywhere
   - sudo sed -i 's/disable_lua = true/disable_lua = false/g' /usr/share/wireshark/init.lua
   - sudo sed -i 's/run_user_scripts_when_superuser = false/run_user_scripts_when_superuser = true/g' /usr/share/wireshark/init.lua
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+dist: trusty
+sudo: required
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y tshark colordiff
+#  - sudo chown root /usr/bin/dumpcap
+#  - sudo chmod u+s /usr/bin/dumpcap
+#  - sudo setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip' /usr/bin/dumpcap
+  # docs say to run as non-root one needs to change settings and log out/back in -
+  # can't be done on travis so this is a workaround
+  # WARNING - don't do this to enable root to run scripts anywhere that isn't travis!
+  - sudo sed -i 's/disable_lua = true/disable_lua = false/g' /usr/share/wireshark/init.lua
+  - sudo sed -i 's/run_user_scripts_when_superuser = false/run_user_scripts_when_superuser = true/g' /usr/share/wireshark/init.lua
+script:
+  - ./.travis/test.sh

--- a/.travis/expected_output
+++ b/.travis/expected_output
@@ -1,0 +1,14 @@
+participant User
+participant Frontend
+participant Logic
+participant Config
+User-&gt;Frontend: GET /index
+Frontend-&gt;Logic: POST /logic
+note right of Frontend: application/json\n \n{&quot;chips&quot;:true,&quot;gravy&quot;:true}
+Logic-&gt;Config: GET /config
+Config--&gt;Logic: 200
+note left of Config: application/json\n \n{&quot;colour&quot;:&quot;red&quot;}
+Logic--&gt;Frontend: 200
+note left of Logic: application/json\n \n{&quot;colour&quot;:&quot;red&quot;,&quot;logic_added&quot;:true}
+Frontend--&gt;User: 200
+note left of Frontend: text/html;charset=utf-8\n \n&lt;h1&gt;hello&lt;/h1&gt;&lt;p&gt;config: {&quot;colour&quot;=&gt;&quot;red&quot;, &quot;logic_added&quot;=&gt;true}

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -d out/ ]; then
+    echo "output directory exists!"
+    exit 1
+fi
+
+# https://unix.stackexchange.com/a/273416
+if [ ! -p in ]; then
+    mkfifo in
+fi
+
+# :( - it is difficult to manage two Gemfiles on travis
+grep ^gem ./test_service/Gemfile >> Gemfile
+# this ensures a Gemfile.lock exists
+bundle install --no-deployment
+
+echo -n "Starting services... "
+./test_service/frontend.rb&
+FRONTEND_PID=$!
+./test_service/logic.rb&
+LOGIC_PID=$!
+./test_service/config.rb&
+CONFIG_PID=$!
+echo "done"
+sudo bash -c "tail -f in | PATH=$PATH GEM_PATH=$GEM_PATH ./generate_html.rb -f -n -r ./test_service/test_participants.yml" &
+APP_PID=$!
+
+function cleanup {
+    echo -n "Shuttting down services... "
+    kill $FRONTEND_PID $LOGIC_PID $CONFIG_PID > /dev/null 2>&1
+    sudo kill $APP_PID
+    echo "done"
+}
+
+trap cleanup EXIT
+
+echo "waiting for app to start" && sleep 5s
+
+# we pretend to be a browser (see PcapToolsHttpMessageRowMapper::BROWSER_USER_AGENT_PATTERN)
+curl -H 'User-Agent: Mozilla' http://127.0.0.1:8000/index
+
+echo "waiting for logs to write" && sleep 5s
+
+# echo does not send a newline (thanks shellcheck)
+printf "exit\n" > in
+
+echo "waiting for app to write data and exit" && sleep 5s
+
+LATEST="$(ls -1t out/ | grep -v html | head -n1)"
+# wait for capture script to exit
+COUNT=0
+while [ $COUNT -lt 10 ]; do
+    if [ -f "out/$LATEST/diagram.html" ]; then
+        break
+    fi
+    COUNT=$[$COUNT+1]
+    sleep 1
+done
+echo "waited $COUNT seconds for file to exist"
+
+colordiff -urN .travis/expected_output <(cat "out/$LATEST/diagram.html" | perl -0pe 's/.*<div class="diagram">\s+(.*)<\/div>.*/$1/gms')
+
+echo "SUCCESS!"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Introduction
+Introduction [![Build Status](https://travis-ci.org/alphagov/interaction-diagrams.svg?branch=master)](https://travis-ci.org/alphagov/interaction-diagrams)
 ------------
 
 The interactions between microservices in applications often evolve to be hard to understand. This tool allows you to generate sequence diagrams of the as-is interactions between microservices. It does this by capturing the traffic between the different microservices when they are all running on a single host.

--- a/generate_html.rb
+++ b/generate_html.rb
@@ -8,7 +8,7 @@ require 'yaml'
 require 'application'
 
 configuration = {
-    :participants => YAML.load_file('participants.yml').map { |participant| Hash[participant.map { |k,v| [k.to_sym,v] }] },
+    :participants => {},
     :participants_to_monitor => [],
     :output_directory => './out',
     :display_request_bodies => true,
@@ -40,6 +40,8 @@ OptionParser.new do |o|
   o.on('--hide_cookies', "Don't display cookie information") do
     configuration[:display_cookies] = false
   end
+
+  configuration[:participants] = YAML.load_file('participants.yml').map { |participant| Hash[participant.map { |k,v| [k.to_sym,v] }] } if File.exists? 'particiants.yml'
 
   o.on('-r <participants file>', "Participants file if not in current directory") do |participants_yml|
     configuration[:participants] = YAML.load_file(participants_yml).map { |participant| Hash[participant.map { |k,v| [k.to_sym,v] }] }

--- a/src/interactive_tcpdump_network_traffic_writer.rb
+++ b/src/interactive_tcpdump_network_traffic_writer.rb
@@ -4,6 +4,8 @@ class InteractiveTcpdumpNetworkTrafficWriter
   end
 
   def write_network_traffic_to(tcpdump_output_file_path)
-    SystemCommandExecutor.invoke_and_kill_on_enter_key_press("tcpdump -q -n -s0 -i lo0 -w #{tcpdump_output_file_path} 'udp or (tcp and (port #{@ports.join(' or port ')}))'", 'Recording network traffic. Press ENTER to stop...')
+    loopback_device = 'lo0'
+    loopback_device = 'lo' if !((RUBY_PLATFORM =~ /linux/).to_i).zero?
+    SystemCommandExecutor.run_tcpdump_and_wait_for_key_press(loopback_device, tcpdump_output_file_path, @ports, 'Recording network traffic. Press ENTER to stop...')
   end
 end

--- a/src/interactive_tcpdump_network_traffic_writer.rb
+++ b/src/interactive_tcpdump_network_traffic_writer.rb
@@ -4,8 +4,8 @@ class InteractiveTcpdumpNetworkTrafficWriter
   end
 
   def write_network_traffic_to(tcpdump_output_file_path)
-    loopback_device = 'lo0'
-    loopback_device = 'lo' if !((RUBY_PLATFORM =~ /linux/).to_i).zero?
+    loopback_device = 'lo0' # macos loopback device
+    loopback_device = 'lo' if !((RUBY_PLATFORM =~ /linux/).to_i).zero? # linux loopback device
     SystemCommandExecutor.run_tcpdump_and_wait_for_key_press(loopback_device, tcpdump_output_file_path, @ports, 'Recording network traffic. Press ENTER to stop...')
   end
 end

--- a/src/util/system_command_executor.rb
+++ b/src/util/system_command_executor.rb
@@ -1,10 +1,11 @@
 class SystemCommandExecutor
-  def self.invoke_and_kill_on_enter_key_press(command, prompt_text)
+  def self.run_tcpdump_and_wait_for_key_press(loopback_device, tcpdump_output_file_path, ports, prompt_text)
     rd, wr = IO.pipe
-    pid = Kernel.spawn(command, :out => wr)
+    pid = Kernel.spawn("tcpdump",  "-q", "-n", "-s0", "-i", loopback_device, "-w", tcpdump_output_file_path, "udp or (tcp and (port #{ports.join(' or port ')}))", :out => wr)
     puts prompt_text
-    gets
+    STDIN.gets
     Process.kill('TERM', pid)
+    Process.wait(pid)
     wr.close
     rd.read
     end

--- a/test_service/capture.sh
+++ b/test_service/capture.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env sh
+#!/usr/bin/env bash
 set -e
 
 cd "$(dirname "$0")"
@@ -26,4 +26,4 @@ cd ..
 bundle check || bundle install
 ./generate_html.rb -f -n -r ./test_service/test_participants.yml
 
-open out/current.html
+open out/current.html || echo "could not open output"


### PR DESCRIPTION
* also adds/fixes Linux support!

* interestingly Kernel.spawn previously ran the command in a shell via
  'sh -c' - this had different behaviour on linux & macos, so there
  are changes here to run the wireshark app directly instead.  We
  don't need to run any other apps at the moment so it's not generic.
  In brief, on linux the shell detached the process it started so the
  TERM signal sent to it did not also stop tcpdump, but in macos the
  signal got to tcpdump and it would stop ¯\_(ツ)_/¯

* this enables root to capture network traffic on travis as enabling a
  user to do that appears impossible without logging out and back
  in...